### PR TITLE
Fix incorrect interaction between forceAlleles and pileup detection

### DIFF
--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -661,13 +661,17 @@ public class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
     @Override
     public ActivityProfileState isActive(final AlignmentContext context, final ReferenceContext ref, final FeatureContext features) {
         MinimalGenotypingEngine localActiveGenotypingEngine = getLocalActiveGenotyper(ref);
-
+        boolean forceCallFlag = false;
         if (forceCallingAllelesPresent && features.getValues(hcArgs.alleles, ref).stream().anyMatch(vc -> hcArgs.forceCallFiltered || vc.isNotFiltered())) {
+            forceCallFlag = true;
             return new ActivityProfileState(ref.getInterval(), 1.0);
         }
 
         if (context == null || context.getBasePileup().isEmpty()) {
             // if we don't have any data, just abort early
+            if (forceCallFlag){
+                return new ActivityProfileState(ref.getInterval(),1.0);
+            }
             return new ActivityProfileState(ref.getInterval(), 0.0);
         }
 
@@ -697,6 +701,10 @@ public class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
                     hcArgs.minBaseQualityScore,
                     averageHQSoftClips, false, hcArgs.activeRegionAltMultiplier)).genotypeLikelihoods;
             genotypes.add(new GenotypeBuilder(sample.getKey()).alleles(noCall).PL(genotypeLikelihoods).make());
+        }
+
+        if (forceCallFlag){
+            return new ActivityProfileState(ref.getInterval(), 1.0);
         }
 
         final List<Allele> alleles = Arrays.asList(FAKE_REF_ALLELE, FAKE_ALT_ALLELE);

--- a/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
+++ b/src/main/java/org/broadinstitute/hellbender/tools/walkers/haplotypecaller/HaplotypeCallerEngine.java
@@ -664,7 +664,6 @@ public class HaplotypeCallerEngine implements AssemblyRegionEvaluator {
         boolean forceCallFlag = false;
         if (forceCallingAllelesPresent && features.getValues(hcArgs.alleles, ref).stream().anyMatch(vc -> hcArgs.forceCallFiltered || vc.isNotFiltered())) {
             forceCallFlag = true;
-            return new ActivityProfileState(ref.getInterval(), 1.0);
         }
 
         if (context == null || context.getBasePileup().isEmpty()) {


### PR DESCRIPTION
Fixed a bug in HaplotypeCaller that did not call active regions correctly when forcedAlleles were present in the case of pileup detection